### PR TITLE
MacOSX supports. IImageHandler service.

### DIFF
--- a/DibToImage.cs
+++ b/DibToImage.cs
@@ -41,6 +41,11 @@ namespace Saraff.Twain {
 
     internal sealed class DibToImage:_ImageHandler {
 
+        /// <summary>
+        /// Convert a block of unmanaged memory to stream.
+        /// </summary>
+        /// <param name="ptr">The pointer to block of unmanaged memory.</param>
+        /// <param name="stream"></param>
         protected override void PtrToStreamCore(IntPtr ptr,Stream stream) {
             BinaryWriter _writer = new BinaryWriter(stream);
 
@@ -63,6 +68,12 @@ namespace Saraff.Twain {
 
         }
 
+        /// <summary>
+        /// Gets the size of a image data.
+        /// </summary>
+        /// <returns>
+        /// Size of a image data.
+        /// </returns>
         protected override int GetSize() {
             if(!this.HandlerState.ContainsKey("DIBSIZE")) {
                 BITMAPINFOHEADER _header = this.Header;
@@ -78,6 +89,12 @@ namespace Saraff.Twain {
             return (int)this.HandlerState["DIBSIZE"];
         }
 
+        /// <summary>
+        /// Gets the size of the buffer.
+        /// </summary>
+        /// <value>
+        /// The size of the buffer.
+        /// </value>
         protected override int BufferSize {
             get {
                 return 256 * 1024; //256K

--- a/DibToImage.cs
+++ b/DibToImage.cs
@@ -39,48 +39,58 @@ using System.Collections.Generic;
 
 namespace Saraff.Twain {
 
-    internal sealed class DibToImage {
-        private const int BufferSize=256*1024; //256K
+    internal sealed class DibToImage:_ImageHandler {
 
-        public static Stream WithStream(IntPtr dibPtr,IStreamProvider provider) {
-            Stream _stream=provider!=null?provider.GetStream():new MemoryStream();
-            BinaryWriter _writer=new BinaryWriter(_stream);
-
-            BITMAPINFOHEADER _bmi=(BITMAPINFOHEADER)Marshal.PtrToStructure(dibPtr,typeof(BITMAPINFOHEADER));
-
-            int _extra=0;
-            if(_bmi.biCompression==0) {
-                int _bytesPerRow=((_bmi.biWidth*_bmi.biBitCount)>>3);
-                _extra=Math.Max(_bmi.biHeight*(_bytesPerRow+((_bytesPerRow&0x3)!=0?4-_bytesPerRow&0x3:0))-_bmi.biSizeImage,0);
-            }
-
-            int _dibSize=_bmi.biSize+_bmi.biSizeImage+_extra+(_bmi.ClrUsed<<2);
+        protected override void PtrToStreamCore(IntPtr ptr,Stream stream) {
+            BinaryWriter _writer = new BinaryWriter(stream);
 
             #region BITMAPFILEHEADER
 
+            BITMAPINFOHEADER _header = this.Header;
+
             _writer.Write((ushort)0x4d42);
-            _writer.Write(14+_dibSize);
+            _writer.Write(14 + this.GetSize());
             _writer.Write(0);
-            _writer.Write(14+_bmi.biSize+(_bmi.ClrUsed<<2));
+            _writer.Write(14 + _header.biSize + (_header.ClrUsed << 2));
 
             #endregion
 
             #region BITMAPINFO and pixel data
 
-            byte[] _buffer = new byte[DibToImage.BufferSize];
-            for(int _offset = 0, _len = 0; _offset<_dibSize; _offset+=_len) {
-                _len=Math.Min(DibToImage.BufferSize,_dibSize-_offset);
-                Marshal.Copy((IntPtr)(dibPtr.ToInt64()+_offset),_buffer,0,_len);
-                _writer.Write(_buffer,0,_len);
-            }
+            base.PtrToStreamCore(ptr,stream);
 
             #endregion
 
-            return _stream;
         }
 
-        public static Stream WithStream(IntPtr dibPtr) {
-            return DibToImage.WithStream(dibPtr,null);
+        protected override int GetSize() {
+            if(!this.HandlerState.ContainsKey("DIBSIZE")) {
+                BITMAPINFOHEADER _header = this.Header;
+
+                int _extra = 0;
+                if(_header.biCompression == 0) {
+                    int _bytesPerRow = ((_header.biWidth * _header.biBitCount) >> 3);
+                    _extra = Math.Max(_header.biHeight * (_bytesPerRow + ((_bytesPerRow & 0x3) != 0 ? 4 - _bytesPerRow & 0x3 : 0)) - _header.biSizeImage,0);
+                }
+
+                this.HandlerState.Add("DIBSIZE",_header.biSize + _header.biSizeImage + _extra + (_header.ClrUsed << 2));
+            }
+            return (int)this.HandlerState["DIBSIZE"];
+        }
+
+        protected override int BufferSize {
+            get {
+                return 256 * 1024; //256K
+            }
+        }
+
+        private BITMAPINFOHEADER Header {
+            get {
+                if(!this.HandlerState.ContainsKey("BITMAPINFOHEADER")) {
+                    this.HandlerState.Add("BITMAPINFOHEADER",Marshal.PtrToStructure(this.ImagePointer,typeof(BITMAPINFOHEADER)));
+                }
+                return this.HandlerState["BITMAPINFOHEADER"] as BITMAPINFOHEADER;
+            }
         }
 
         [StructLayout(LayoutKind.Sequential,Pack=2)]
@@ -109,17 +119,5 @@ namespace Saraff.Twain {
                 }
             }
         }
-    }
-
-    /// <summary>
-    /// Provides instances of the <see cref="System.IO.Stream"/> for data writing.
-    /// </summary>
-    public interface IStreamProvider {
-
-        /// <summary>
-        /// Gets the stream.
-        /// </summary>
-        /// <returns>The stream.</returns>
-        Stream GetStream();
     }
 }

--- a/Pict.cs
+++ b/Pict.cs
@@ -8,10 +8,22 @@ namespace Saraff.Twain {
 
     internal sealed class Pict:_ImageHandler {
 
+        /// <summary>
+        /// Gets the size of a image data.
+        /// </summary>
+        /// <returns>
+        /// Size of a image data.
+        /// </returns>
         protected override int GetSize() {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Gets the size of the buffer.
+        /// </summary>
+        /// <value>
+        /// The size of the buffer.
+        /// </value>
         protected override int BufferSize {
             get {
                 return 256 * 1024; //256K

--- a/Pict.cs
+++ b/Pict.cs
@@ -6,32 +6,16 @@ using System.Text;
 
 namespace Saraff.Twain {
 
-    internal sealed class Pict {
-        private const int BufferSize=256*1024; //256K
+    internal sealed class Pict:_ImageHandler {
 
-        private static Pict FromPtr(IntPtr ptr) {
+        protected override int GetSize() {
             throw new NotImplementedException();
         }
 
-        public static Stream FromPtrToImage(IntPtr ptr,IStreamProvider provider) {
-            Pict _pict=Pict.FromPtr(ptr);
-            Stream _stream=provider!=null?provider.GetStream():new MemoryStream();
-            BinaryWriter _writer=new BinaryWriter(_stream);
-
-            int _tiffSize=_pict._GetSize();
-            byte[] _buffer=new byte[Pict.BufferSize];
-
-            for(int _offset=0, _len=0; _offset<_tiffSize; _offset+=_len) {
-                _len=Math.Min(Pict.BufferSize,_tiffSize-_offset);
-                Marshal.Copy((IntPtr)(ptr.ToInt64()+_offset),_buffer,0,_len);
-                _writer.Write(_buffer,0,_len);
+        protected override int BufferSize {
+            get {
+                return 256 * 1024; //256K
             }
-
-            return _stream;
-        }
-
-        private int _GetSize() {
-            throw new NotImplementedException();
         }
     }
 }

--- a/Pict.cs
+++ b/Pict.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Saraff.Twain {
+
+    internal sealed class Pict {
+        private const int BufferSize=256*1024; //256K
+
+        private static Pict FromPtr(IntPtr ptr) {
+            throw new NotImplementedException();
+        }
+
+        public static Stream FromPtrToImage(IntPtr ptr,IStreamProvider provider) {
+            Pict _pict=Pict.FromPtr(ptr);
+            Stream _stream=provider!=null?provider.GetStream():new MemoryStream();
+            BinaryWriter _writer=new BinaryWriter(_stream);
+
+            int _tiffSize=_pict._GetSize();
+            byte[] _buffer=new byte[Pict.BufferSize];
+
+            for(int _offset=0, _len=0; _offset<_tiffSize; _offset+=_len) {
+                _len=Math.Min(Pict.BufferSize,_tiffSize-_offset);
+                Marshal.Copy((IntPtr)(ptr.ToInt64()+_offset),_buffer,0,_len);
+                _writer.Write(_buffer,0,_len);
+            }
+
+            return _stream;
+        }
+
+        private int _GetSize() {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -62,5 +62,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.26.602")]
-[assembly: AssemblyFileVersion("1.0.26.602")]
+[assembly: AssemblyVersion("1.0.26.605")]
+[assembly: AssemblyFileVersion("1.0.26.605")]

--- a/Saraff.Twain.csproj
+++ b/Saraff.Twain.csproj
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DibToImage.cs" />
+    <Compile Include="Pict.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/Saraff.Twain.csproj
+++ b/Saraff.Twain.csproj
@@ -66,6 +66,7 @@
     <Compile Include="TwainCapabilities.cs" />
     <Compile Include="TwainDefs.cs" />
     <Compile Include="TwainException.cs" />
+    <Compile Include="_ImageHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.resx">

--- a/Tiff.cs
+++ b/Tiff.cs
@@ -41,6 +41,12 @@ namespace Saraff.Twain {
 
     internal sealed class Tiff:_ImageHandler {
 
+        /// <summary>
+        /// Convert a block of unmanaged memory to stream.
+        /// </summary>
+        /// <param name="ptr">The pointer to block of unmanaged memory.</param>
+        /// <param name="stream"></param>
+        /// <exception cref="NotSupportedException"></exception>
         protected override void PtrToStreamCore(IntPtr ptr,Stream stream) {
             if(this.Header.magic == MagicValues.BigEndian) {
                 throw new NotSupportedException();
@@ -48,6 +54,12 @@ namespace Saraff.Twain {
             base.PtrToStreamCore(ptr,stream);
         }
 
+        /// <summary>
+        /// Gets the size of a image data.
+        /// </summary>
+        /// <returns>
+        /// Size of a image data.
+        /// </returns>
         protected override int GetSize() {
             if(!this.HandlerState.ContainsKey("TIFFSIZE")) {
                 int _size = 0;
@@ -101,6 +113,12 @@ namespace Saraff.Twain {
             return (int)this.HandlerState["TIFFSIZE"];
         }
 
+        /// <summary>
+        /// Gets the size of the buffer.
+        /// </summary>
+        /// <value>
+        /// The size of the buffer.
+        /// </value>
         protected override int BufferSize {
             get {
                 return 256 * 1024; //256K

--- a/Tiff.cs
+++ b/Tiff.cs
@@ -40,6 +40,7 @@ using System.Collections.ObjectModel;
 namespace Saraff.Twain {
 
     internal sealed class Tiff {
+        private const int BufferSize=256*1024; //256K
         private TiffHeader _header;
         private Tiff.Ifd _ifd;
 
@@ -54,11 +55,21 @@ namespace Saraff.Twain {
             return _tiff;
         }
 
-        public static Stream FromPtrToImage(IntPtr ptr) {
+        public static Stream FromPtrToImage(IntPtr ptr,IStreamProvider provider) {
             Tiff _tiff=Tiff.FromPtr(ptr);
-            byte[] _tiffData=new byte[_tiff._GetSize()];
-            Marshal.Copy(ptr,_tiffData,0,_tiffData.Length);
-            return new MemoryStream(_tiffData);
+            Stream _stream=provider!=null?provider.GetStream():new MemoryStream();
+            BinaryWriter _writer = new BinaryWriter(_stream);
+
+            int _tiffSize=_tiff._GetSize();
+            byte[] _buffer = new byte[Tiff.BufferSize];
+
+            for(int _offset=0, _len=0; _offset<_tiffSize; _offset+=_len) {
+                _len=Math.Min(Tiff.BufferSize,_tiffSize-_offset);
+                Marshal.Copy((IntPtr)(ptr.ToInt64()+_offset),_buffer,0,_len);
+                _writer.Write(_buffer,0,_len);
+            }
+
+            return _stream;
         }
 
         private int _GetSize() {

--- a/_ImageHandler.cs
+++ b/_ImageHandler.cs
@@ -6,12 +6,24 @@ using System.Text;
 
 namespace Saraff.Twain {
 
+    /// <summary>
+    /// Base class to processing of a acquired image.
+    /// </summary>
+    /// <seealso cref="Saraff.Twain.IImageHandler" />
     internal abstract class _ImageHandler:IImageHandler {
         private Dictionary<string,object> _state = null;
         private const string _ImagePointer = "ImagePointer";
 
         #region IImageHandler
 
+        /// <summary>
+        /// Convert a block of unmanaged memory to stream.
+        /// </summary>
+        /// <param name="ptr">The pointer to block of unmanaged memory.</param>
+        /// <param name="provider">The provider of a streams.</param>
+        /// <returns>
+        /// Stream that contains data of a image.
+        /// </returns>
         public Stream PtrToStream(IntPtr ptr,IStreamProvider provider) {
             this._state = new Dictionary<string,object> {
                 {_ImageHandler._ImagePointer, ptr}
@@ -24,6 +36,11 @@ namespace Saraff.Twain {
 
         #endregion
 
+        /// <summary>
+        /// Convert a block of unmanaged memory to stream.
+        /// </summary>
+        /// <param name="ptr">The pointer to block of unmanaged memory.</param>
+        /// <param name="provider">The provider of a streams.</param>
         protected virtual void PtrToStreamCore(IntPtr ptr,Stream stream) {
             BinaryWriter _writer = new BinaryWriter(stream);
 
@@ -37,18 +54,40 @@ namespace Saraff.Twain {
             }
         }
 
+        /// <summary>
+        /// Gets the size of a image data.
+        /// </summary>
+        /// <returns>Size of a image data.</returns>
         protected abstract int GetSize();
 
+        /// <summary>
+        /// Gets the size of the buffer.
+        /// </summary>
+        /// <value>
+        /// The size of the buffer.
+        /// </value>
         protected abstract int BufferSize {
             get;
         }
 
+        /// <summary>
+        /// Gets the state of the handler.
+        /// </summary>
+        /// <value>
+        /// The state of the handler.
+        /// </value>
         protected Dictionary<string,object> HandlerState {
             get {
                 return this._state;
             }
         }
 
+        /// <summary>
+        /// Gets the pointer to unmanaged memory that contain image data.
+        /// </summary>
+        /// <value>
+        /// The image pointer.
+        /// </value>
         protected IntPtr ImagePointer {
             get {
                 return (IntPtr)this.HandlerState[_ImageHandler._ImagePointer];
@@ -56,8 +95,17 @@ namespace Saraff.Twain {
         }
     }
 
+    /// <summary>
+    /// Provides processing of a acquired image.
+    /// </summary>
     public interface IImageHandler {
 
+        /// <summary>
+        /// Convert a block of unmanaged memory to stream.
+        /// </summary>
+        /// <param name="ptr">The pointer to block of unmanaged memory.</param>
+        /// <param name="provider">The provider of a streams.</param>
+        /// <returns>Stream that contains data of a image.</returns>
         Stream PtrToStream(IntPtr ptr,IStreamProvider provider);
     }
 

--- a/_ImageHandler.cs
+++ b/_ImageHandler.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Saraff.Twain {
+
+    internal abstract class _ImageHandler:IImageHandler {
+        private Dictionary<string,object> _state = null;
+        private const string _ImagePointer = "ImagePointer";
+
+        #region IImageHandler
+
+        public Stream PtrToStream(IntPtr ptr,IStreamProvider provider) {
+            this._state = new Dictionary<string,object> {
+                {_ImageHandler._ImagePointer, ptr}
+            };
+
+            Stream _stream = provider != null ? provider.GetStream() : new MemoryStream();
+            this.PtrToStreamCore(ptr,_stream);
+            return _stream;
+        }
+
+        #endregion
+
+        protected virtual void PtrToStreamCore(IntPtr ptr,Stream stream) {
+            BinaryWriter _writer = new BinaryWriter(stream);
+
+            int _size = this.GetSize();
+            byte[] _buffer = new byte[this.BufferSize];
+
+            for(int _offset = 0, _len = 0; _offset < _size; _offset += _len) {
+                _len = Math.Min(this.BufferSize,_size - _offset);
+                Marshal.Copy((IntPtr)(ptr.ToInt64() + _offset),_buffer,0,_len);
+                _writer.Write(_buffer,0,_len);
+            }
+        }
+
+        protected abstract int GetSize();
+
+        protected abstract int BufferSize {
+            get;
+        }
+
+        protected Dictionary<string,object> HandlerState {
+            get {
+                return this._state;
+            }
+        }
+
+        protected IntPtr ImagePointer {
+            get {
+                return (IntPtr)this.HandlerState[_ImageHandler._ImagePointer];
+            }
+        }
+    }
+
+    public interface IImageHandler {
+
+        Stream PtrToStream(IntPtr ptr,IStreamProvider provider);
+    }
+
+    /// <summary>
+    /// Provides instances of the <see cref="System.IO.Stream"/> for data writing.
+    /// </summary>
+    public interface IStreamProvider {
+
+        /// <summary>
+        /// Gets the stream.
+        /// </summary>
+        /// <returns>The stream.</returns>
+        Stream GetStream();
+    }
+}


### PR DESCRIPTION
Ревизия: 605
Автор: SARAFF
Дата: 20 августа 2017 г. 22:55:22
Сообщение:
Добавлена поддержка платформы MacOSX.
Добавлена возможность расширения расширения функциональности через IImageHandler.

----
Изменённые : /C#/Saraff.Twain/Saraff.Twain/DibToImage.cs
Добавленные : /C#/Saraff.Twain/Saraff.Twain/Pict.cs
Изменённые : /C#/Saraff.Twain/Saraff.Twain/Saraff.Twain.csproj
Изменённые : /C#/Saraff.Twain/Saraff.Twain/Tiff.cs
Изменённые : /C#/Saraff.Twain/Saraff.Twain/Twain32.cs
Добавленные : /C#/Saraff.Twain/Saraff.Twain/_ImageHandler.cs

